### PR TITLE
PR for issue #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ export default defineConfig({
         generate: true,
         outFile: path.resolve(__dirname, './src/style.d.ts'),
       },
+      enabledMode: ['development', 'production'],
     }),
   ],
 })

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ npm i -D vite-plugin-sass-dts
 
 ## Options
 
-| Parameter       | Type    | Description                                                                                                                                                                                                       |
-| --------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| allGenerate     | boolean | Create all d.ts files of the css, sass, scss files included in the project at build time.<br />We recommend that you turn off the flag once you have created the d.ts file, as it will take a long time to build. |
-| global.generate | boolean | Outputs the common style set in <b>additionalData</b> of <b>preprocessorOptions</b> as a global type definition file.                                                                                             |
-| global.outFile  | string  | Specify the file that outputs the global common style with an absolute path.Relative paths will be supported.                                                                                                     |
+| Parameter       | Type     | Description                                                                                                                                                                                                                                                                                                                                 |
+| --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| enabledMode     | string[] | Create d.ts files for css modules of file extension css, sass, scss included in the project at build time.<br /><br>Valid enumerations 'development' and 'production'. By default it is enabled only for development.<br>We recommend that you turn off the flag once you have created the d.ts file, as it will take a long time to build. |
+| global.generate | boolean  | Outputs the common style set in <b>additionalData</b> of <b>preprocessorOptions</b> as a global type definition file.                                                                                                                                                                                                                       |
+| global.outFile  | string   | Specify the file that outputs the global common style with an absolute path.Relative paths will be supported.                                                                                                                                                                                                                               |
 
 ## Add it to vite.config.ts
 
@@ -72,12 +72,11 @@ export default defineConfig({
   plugins: [
     react(),
     sassDts({
-      allGenerate: true,
+      enabledMode: ['development', 'production'],
       global: {
         generate: true,
         outFile: path.resolve(__dirname, './src/style.d.ts'),
       },
-      enabledMode: ['development', 'production'],
     }),
   ],
 })

--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "serve": "vite preview",
-    "local:link": "npm link vite-plugin-sass-dts",
+    "local:link": "npm link ../",
     "local:start": "npm run local:link && npm run dev"
   },
   "author": "",

--- a/example/src/index.css.d.ts
+++ b/example/src/index.css.d.ts
@@ -1,4 +1,0 @@
-import globalClassNames, { ClassNames as GlobalClassNames } from './style.d'
-declare const classNames: typeof globalClassNames & {}
-export default classNames
-export type ClassNames = GlobalClassNames

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
   plugins: [
     react(),
     sassDts({
-      allGenerate: true,
+      enabledMode: ['development', 'production'],
       global: {
         generate: true,
         outFile: path.resolve(__dirname, './src/style.d.ts'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export default function Plugin(option: PluginOption = {}): Plugin {
       return
     },
     transform(code, id) {
-      if (!option.allGenerate || !enabledMode.includes(cacheConfig.env.mode)) {
+      if (!enabledMode.includes(cacheConfig.env.mode)) {
         return { code }
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export default function Plugin(option: PluginOption = {}): Plugin {
       return
     },
     transform(code, id) {
-      if (!enabledMode.includes(cacheConfig.env.mode)) {
+      if (!enabledMode.includes(cacheConfig.env.MODE)) {
         return { code }
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,11 @@ import prettier from 'prettier'
 import { Plugin } from 'vite'
 import { main } from './main'
 import { FinalConfig, PluginOption } from './type'
-import { isCSSRequest } from './util'
+import { isCSSModuleRequest } from './util'
 
 export default function Plugin(option: PluginOption = {}): Plugin {
   let cacheConfig: FinalConfig
+  const enabledMode = option.enabledMode || ['development']
   return {
     name: 'vite-plugin-sass-dts',
     async configResolved(config) {
@@ -16,17 +17,17 @@ export default function Plugin(option: PluginOption = {}): Plugin {
       }
     },
     handleHotUpdate(context) {
-      if (!isCSSRequest(context.file)) return
+      if (!isCSSModuleRequest(context.file)) return
       main(context.file, cacheConfig, option)
       return
     },
     transform(code, id) {
-      if (!option.allGenerate) {
+      if (!option.allGenerate || !enabledMode.includes(cacheConfig.env.mode)) {
         return { code }
       }
 
       const fileName = id.replace('?used', '')
-      if (!isCSSRequest(fileName)) return { code }
+      if (!isCSSModuleRequest(fileName)) return { code }
 
       main(fileName, cacheConfig, option)
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -10,6 +10,7 @@ export type AdditionalData =
 export type PluginOption = {
   allGenerate?: boolean
   global?: { generate: boolean; outFile: string }
+  enabledMode?: string[]
 }
 
 export type CSS = { localStyle: string; globalStyle?: string }

--- a/src/type.ts
+++ b/src/type.ts
@@ -8,9 +8,8 @@ export type AdditionalData =
   | ((source: string, filename: string) => string | Promise<string>)
 
 export type PluginOption = {
-  allGenerate?: boolean
+  enabledMode?: ('development' | 'production')[]
   global?: { generate: boolean; outFile: string }
-  enabledMode?: string[]
 }
 
 export type CSS = { localStyle: string; globalStyle?: string }

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,9 +3,13 @@ import type { SassException } from 'sass'
 
 export const cssLangs = `\\.(css|sass|scss)($|\\?)`
 export const cssLangReg = new RegExp(cssLangs)
+export const cssModuleReg = new RegExp(`\\.module${cssLangs}`)
 
 export const isCSSRequest = (request: string): boolean =>
   cssLangReg.test(request)
+
+export const isCSSModuleRequest = (request: string): boolean =>
+  cssModuleReg.test(request)
 
 export const getRelativePath = (
   from: string | undefined,


### PR DESCRIPTION
  1. generate only for css modules
  2. replaced allGenerate with enabledMode flag
  3. Improved npm link on example
  4. Updated example - removed non-css modules .d.ts files that were previously present
  
Linting/Prettier passes