### PR TITLE
fix: support multiple imports in a file

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1,7 +1,7 @@
 import { collectionToObj } from './util'
 import type { CSSJSObj, GetParseCaseFunction } from './type'
 
-const importRe = new RegExp(/^(@import)/g)
+const importRe = new RegExp(/^(@import)/)
 const keySeparatorRe = new RegExp(/(?=[\s.:[\]><+,()])/g)
 
 export const extractClassNameKeys = (


### PR DESCRIPTION
If you try to use two imports, like this:

```
@import '../../../css/variables.css';
@import '../../../css/typography.module.css';
```

you will get:

```
SyntaxError: Property or signature expected. (6:3)
  4 |   readonly '/css/typography': '/css/typography';
  5 |   readonly 'module': 'module';
> 6 |   readonly 'css'': 'css'';
    |   ^
  7 |   readonly 'page': 'page';
  8 |   readonly 'head': 'head';
  9 |   readonly 'avatar': 'avatar';
```

Check on https://github.com/activeguild/vite-plugin-sass-dts/blob/2d568e74568db7a555743e52d55140a6c6392b5e/src/extract.ts#L14 will not work, because of `g` regexp flag.