### PR TITLE
fix: remove source map warnings for files that are not processed by vite-plugin-sass-dts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,9 @@ export default function Plugin(option: PluginOptions = {}): VitePlugin {
         !enabledMode.includes(cacheConfig.env.MODE) ||
         !isCSSModuleRequest(fileName)
       ) {
-        return { code }
+        // returning undefined will signal vite that the file has not been transformed 
+        // avoiding warnings about source maps not being generated
+        return undefined;
       }
 
       return new Promise((resolve) =>


### PR DESCRIPTION
Vite issues the following warning when ignoring files for transformation.

```
Sourcemap is likely to be incorrect: a plugin (vite-plugin-sass-dts) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
```

It will also break source maps as the warning states. Returning `undefined` from the transformation function will remove the warning and fix broken source maps.