### PR TITLE
Update postcss-js to fix :export issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.14",
       "license": "MIT",
       "dependencies": {
-        "postcss-js": "^4.0.0"
+        "postcss-js": "^4.0.1"
       },
       "devDependencies": {
         "@types/prettier": "^2.7.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/activeguild/vite-plugin-sass-dts#readme",
   "dependencies": {
-    "postcss-js": "^4.0.0"
+    "postcss-js": "^4.0.1"
   },
   "devDependencies": {
     "@types/prettier": "^2.7.2",


### PR DESCRIPTION
We're currently using a your plugin to generate *.d.ts files from *.module.scss in our project.
There was an issue with the postcss-js `objectify()` function which turned this:

```sass
:export {
  caseSensitiveVariable: 1px
}
```

into this:

```json
{
  ":export": {
    "casesensitivevariable": "1px"
  }
}
```

We made a PR was on the `postcss-js` repo to fix the issue and it got merged and released yesterday.
This is a PR to update `postcss-js` dependency on your package, which should fix the issue.
After this gets released we can stop using patch-package in our project! 🎉 