### PR TITLE
Replace path separators in relative path

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -18,6 +18,9 @@ export const getRelativePath = (
   to: string | undefined
 ) => {
   let relativePath = path.relative(from || '', to || '') || './'
+  if (path.sep !== "/") {
+    relativePath = relativePath.replaceAll(path.sep, "/")
+  }
   relativePath = sameDirRE.test(relativePath)
     ? relativePath
     : `./${relativePath}`


### PR DESCRIPTION
When calculating the relative path, the system-specific path separator is used.

This causes problems when injecting the path later, replace any separator that's not "/" with "/"

This fixes #89