### PR TITLE
Remove `console.log` in `configResolved`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ export default function Plugin(option: PluginOptions = {}): VitePlugin {
   return {
     name: 'vite-plugin-sass-dts',
     async configResolved(config) {
-      console.log('config.root :>> ', config.root)
       const prettierOptions =
         (await resolveConfig(option.prettierFilePath || config.root)) || {}
       cacheConfig = {


### PR DESCRIPTION
Hi 👋 ,

Thanks for making `vite-plugin-sass-dts`! It fits our use case perfectly.

Could this `console.log` in `configResolved` be removed? It appears every time we run `vite dev`

![image](https://github.com/user-attachments/assets/0643277f-5f2e-4804-9b3a-59f93098d50b)
