### PR TITLE
fix: support files with a .pcss extension

### DIFF
--- a/src/css.ts
+++ b/src/css.ts
@@ -24,7 +24,7 @@ export const parseCss = async (
 
   const options = getPreprocessorOptions(config)
   const resolveFn = config.createResolver({
-    extensions: ['.scss', '.sass', '.css'],
+    extensions: ['.scss', '.sass', '.pcss', '.css'],
     mainFields: ['sass', 'style'],
     tryIndex: true,
     tryPrefix: '_',

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import type { Exception } from 'sass-embedded'
 
-export const cssLangs = `\\.(css|sass|scss)($|\\?)`
+export const cssLangs = `\\.(css|pcss|sass|scss)($|\\?)`
 export const cssLangReg = new RegExp(cssLangs)
 export const cssModuleReg = new RegExp(`\\.module${cssLangs}`)
 export const importCssRE = /@import ('[^']+\.css'|"[^"]+\.css"|[^'")]+\.css)/


### PR DESCRIPTION
This extension is sometimes used when using postcss and is supported out of the box with e.g. Vite. The files have the same syntax as css files, so it should work without further changes.