### PR TITLE
新しい定義ファイルフォーマットの取り込み

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ we have confirmed that it does not work with the [sass](https://www.npmjs.com/pa
 | esmExport             | boolean                                | Specify dts export type. If enabled, going to use ESM style export `export default ...`. Otherwise `export = ...`.                                                                                                                                                                                                                                                    |
 | prettierFilePath      | string                                 | Specify the path to the prettier configuration file.                                                                                                                                                                                                                                                                                                                  |
 | useNamedExport        | boolean                                | Output also in named export.(default: false)                                                                                                                                                                                                                                                                                                                          |
+| legacyFileFormat      | boolean                                | Use legacy file naming format. If `true`, generates `*.scss.d.ts` (legacy). If `false`, generates `*.d.scss.ts` (TypeScript 5 compatible). (default: `false`)                                                                                                                                                                                                         |
 
 ## Add it to vite.config.ts
 
@@ -129,7 +130,9 @@ Saving the scss file creates a d.ts file in the `outputDir` hierarchy.
 
 > Note: if `outputDir` is not set, declaration files are output to the same directory as the source files.
 
-[dist/App.scss.d.ts]
+> **TypeScript 5 Compatibility**: By default, declaration files are generated in the format `*.d.scss.ts` (e.g., `App.module.d.scss.ts`) which is compatible with TypeScript 5's module resolution. To use the legacy format `*.scss.d.ts`, set `legacyFileFormat: true` in the plugin options.
+
+[dist/App.module.d.scss.ts]
 
 ```ts
 import globalClassNames, { ClassNames as GlobalClassNames } from './style.d'

--- a/src/type.ts
+++ b/src/type.ts
@@ -18,6 +18,7 @@ export type PluginOptions = {
   excludePath?: string | RegExp | Array<string | RegExp>
   prettierFilePath?: string
   useNamedExport?: boolean
+  legacyFileFormat?: boolean
 }
 
 export type CSS = { localStyle: string; globalStyle?: string }

--- a/src/write.ts
+++ b/src/write.ts
@@ -103,11 +103,31 @@ export const formatWriteFilePath = (file: string, options?: PluginOptions) => {
     path = path.replace(src, dist)
   }
 
-  return formatWriteFileName(path)
+  return formatWriteFileName(path, options?.legacyFileFormat)
 }
 
-export const formatWriteFileName = (file: string) =>
-  `${file}${file.endsWith('d.ts') ? '' : '.d.ts'}`
+export const formatWriteFileName = (file: string, legacyFormat = false) => {
+  if (file.endsWith('d.ts')) {
+    return file
+  }
+
+  if (legacyFormat) {
+    // Legacy format: sample.module.scss.d.ts
+    return `${file}.d.ts`
+  }
+
+  // TypeScript 5 format: sample.module.d.scss.ts
+  // Extract the file extension (e.g., .scss, .sass, .css)
+  const extensionMatch = file.match(/\.(scss|sass|css)$/)
+  if (extensionMatch) {
+    const extension = extensionMatch[1]
+    const basePath = file.slice(0, -extension.length - 1) // Remove .scss/.sass/.css
+    return `${basePath}.d.${extension}.ts`
+  }
+
+  // Fallback for unknown extensions
+  return `${file}.d.ts`
+}
 
 export const formatExportTypeFileName = (file: string) =>
   basename(file.replace('.ts', ''))


### PR DESCRIPTION
## 対応完了

Issue #119の対応が完了しました。以下の変更を実装しました：

### 主な変更点

1. **TypeScript 5対応のファイル形式をデフォルトに変更**
   - 新しい形式：`*.d.scss.ts`、`*.d.sass.ts`、`*.d.css.ts`
   - 従来の形式：`*.scss.d.ts` (オプションで使用可能)

2. **新しいオプション `legacyFileFormat` を追加** (src/type.ts:21)
   - `false` (デフォルト): TypeScript 5互換の形式 (`*.d.scss.ts`)
   - `true`: 従来の形式 (`*.scss.d.ts`)

3. **`formatWriteFileName` 関数を更新** (src/write.ts:109-130)
   - ファイル拡張子 (`.scss`, `.sass`, `.css`) を検出
   - TypeScript 5形式でファイル名を生成
   - 後方互換性のためのレガシーモードをサポート

4. **READMEを更新**
   - 新しいオプションをドキュメントに追加
   - TypeScript 5互換性についての注記を追加
   - サンプルのファイル名を `App.module.d.scss.ts` に更新

### テスト結果
すべてのファイル形式で正しく動作することを確認：
- ✓ SCSS: `App.module.d.scss.ts`
- ✓ SASS: `App.module.d.sass.ts`
- ✓ CSS: `App.module.d.css.ts`
- ✓ レガシー形式: `App.module.scss.d.ts`

この変更により、TypeScript 5の `moduleResolution: "bundler"` または `"node16/nodenext"` 設定で正しく型定義が解決されるようになります。